### PR TITLE
idをULIDに変更し、idに対するバリデーションチェックを削除しました

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,8 @@
   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"banana sugimoto"</span></span>,
   "<span class="hljs-attribute">bithdate</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>201</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
-  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
-  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"user successfully created"</span>
+   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">01</span>FZMTP19VSKWBQPXJA4GKZ2Y3</span>,
+   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"user successfully created"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>400</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"validation error"</span></span>,
   "<span class="hljs-attribute">errors</span>": <span class="hljs-value">[
@@ -34,17 +34,11 @@
     </span>}
   ]
 </span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="users--1" class="resource"><h3 class="resource-heading">Resource <a href="#users--1" class="permalink">&nbsp;&para;</a></h3><div id="users-get" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#users-get" class="method get">GET</a><code class="uri">/users/{id}</code></h4><p>idに指定したユーザーの情報を取得します。</p>
-<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>ユーザーのID</p>
+<h4>Example URI</h4><div class="definition"><span class="method get">GET</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/<span class="hljs-attribute" title="id">01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span><p>ユーザーのID。採番は26文字のULID。</p>
 </dd></dl></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
-  "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
-  "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"banana sugimoto"</span></span>,
-  "<span class="hljs-attribute">birthdate</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01"</span>
-</span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>400</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
-  "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"validation error"</span></span>,
-  "<span class="hljs-attribute">error</span>": <span class="hljs-value">{
-    "<span class="hljs-attribute">field</span>": <span class="hljs-value"><span class="hljs-string">"id"</span></span>,
-    "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"cannot be string"</span>
-  </span>}
+   "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">01</span>FZMTP19VSKWBQPXJA4GKZ2Y3</span>,
+   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"banana sugimoto"</span></span>,
+   "<span class="hljs-attribute">birthdate</span>": <span class="hljs-value"><span class="hljs-string">"2022-01-01"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"user not found"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div></div></div><div id="users--2" class="resource"><h3 class="resource-heading">Resource <a href="#users--2" class="permalink">&nbsp;&para;</a></h3><div id="users-get-1" class="action get"><h4 class="action-heading"><div class="name"></div><a href="#users-get-1" class="method get">GET</a><code class="uri">/users</code></h4><p>ユーザーを検索します。</p>
@@ -52,7 +46,7 @@
 </dd><dt>birthdate</dt><dd><code>string</code>&nbsp;<span>(optional)</span>&nbsp;<p>yyyy-MM-dd形式。完全一致で検索。</p>
 </dd></dl></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>[
     {
-        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">1</span></span>,
+        "<span class="hljs-attribute">id</span>": <span class="hljs-value"><span class="hljs-number">01</span>FZMTP19VSKWBQPXJA4GKZ2Y3</span>,
         "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"banana sugimoto"</span>
         <span class="hljs-string">"birthdate"</span>: <span class="hljs-string">"2022-01-01"</span>
     </span>}
@@ -65,9 +59,9 @@
 <p>birthdate (string, required) - 生年月日。yyyy-MM-dd形式。未来日付は不可。</p>
 </li>
 </ul>
-<h4>Example URI</h4><div class="definition"><span class="method patch">PATCH</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>ユーザーのID</p>
+<h4>Example URI</h4><div class="definition"><span class="method patch">PATCH</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/<span class="hljs-attribute" title="id">01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span><p>ユーザーのID。採番は26文字のULID。</p>
 </dd></dl></div><div class="title"><strong>Request</strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
-    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"banana sugimoto"</span>
+    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"ringo sugimoto"</span>
     <span class="hljs-string">"birthdate"</span>: <span class="hljs-string">"2022-01-01"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"user successfully updated"</span>
@@ -96,7 +90,7 @@
 <ul>
 <li>deleted (boolean) - 削除フラグ。0:有効、1:削除。</li>
 </ul>
-<h4>Example URI</h4><div class="definition"><span class="method patch">PATCH</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/delete/<span class="hljs-attribute" title="id">1</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>number</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>1</span></span><p>ユーザーのID</p>
+<h4>Example URI</h4><div class="definition"><span class="method patch">PATCH</span>&nbsp;<span class="uri"><span class="hostname"></span>/users/delete/<span class="hljs-attribute" title="id">01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span></div><div class="title"><strong>URI Parameters</strong><div class="collapse-button show"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><dl class="inner"><dt>id</dt><dd><code>string</code>&nbsp;<span class="required">(required)</span>&nbsp;<span class="text-muted example"><strong>Example:&nbsp;</strong><span>01FZMTP19VSKWBQPXJA4GKZ2Y3</span></span><p>ユーザーのID。採番は26文字のULID。</p>
 </dd></dl></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"user successfully deleted"</span>
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>404</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
@@ -111,7 +105,7 @@
 <pre><code class="language-json">{
   "<span class="hljs-attribute">message</span>": <span class="hljs-value"><span class="hljs-string">"system error"</span>
 </span>}</code></pre>
-</section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 26 May 2022</p><script>/* eslint-env browser */
+</section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 29 May 2022</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/md/user-api.md
+++ b/md/user-api.md
@@ -20,7 +20,7 @@ FORMAT: 1A
 + Response 201 (application/json)
   + Body
         {
-           "id": 1,
+           "id": 01FZMTP19VSKWBQPXJA4GKZ2Y3,
            "message": "user successfully created"
         }
 
@@ -51,24 +51,14 @@ FORMAT: 1A
 idに指定したユーザーの情報を取得します。
 
 + Parameters
-  + id: 1 (number) - ユーザーのID
+  + id: 01FZMTP19VSKWBQPXJA4GKZ2Y3 - ユーザーのID。採番は26文字のULID。
 
 + Response 200 (application/json)
   + Body
         {
-           "id": 1,
+           "id": 01FZMTP19VSKWBQPXJA4GKZ2Y3,
            "name": "banana sugimoto",
            "birthdate": "2022-01-01"
-        } 
-
-+ Response 400 (application/json)
-  + Body
-        {
-            "message":"validation error",
-            "error":{
-                "field":"id",
-                "message":"cannot be string"
-            }
         }
 
 + Response 404 (application/json)
@@ -88,7 +78,7 @@ idに指定したユーザーの情報を取得します。
   + Body
         [
             {
-                "id": 1,
+                "id": 01FZMTP19VSKWBQPXJA4GKZ2Y3,
                 "name": "banana sugimoto"
                 "birthdate": "2022-01-01"
             }
@@ -105,12 +95,12 @@ idに指定したユーザーの情報を更新します。
 + birthdate (string, required) - 生年月日。yyyy-MM-dd形式。未来日付は不可。
 
 + Parameters
-  + id: 1(number) - ユーザーのID
+  + id: 01FZMTP19VSKWBQPXJA4GKZ2Y3 - ユーザーのID。採番は26文字のULID。
 
 + Request (application/json)
   + Body
         {
-            "name": "banana sugimoto"
+            "name": "ringo sugimoto"
             "birthdate": "2022-01-01"
         }
 
@@ -155,7 +145,7 @@ idに指定したユーザーの情報を論理削除します。
 + deleted (boolean) - 削除フラグ。0:有効、1:削除。
 
 + Parameters
-  + id: 1 (number) - ユーザーのID
+  + id: 01FZMTP19VSKWBQPXJA4GKZ2Y3 - ユーザーのID。採番は26文字のULID。
 
 + Response 200 (application/json)
   + Body


### PR DESCRIPTION
#10 
# 概要
API仕様書のidの採番をULIDに変更しました。

# 変更点
- Example URIのidを26文字のULIDに修正
- idを指定するGETメソッドのidに対するバリデーションチェックを削除